### PR TITLE
10월 4주차 스프린트 PR

### DIFF
--- a/src/main/java/kr/co/seulchuksaeng/seulchuksaengweb/controller/EventController.java
+++ b/src/main/java/kr/co/seulchuksaeng/seulchuksaengweb/controller/EventController.java
@@ -8,6 +8,8 @@ import kr.co.seulchuksaeng.seulchuksaengweb.dto.form.*;
 import kr.co.seulchuksaeng.seulchuksaengweb.dto.result.*;
 import kr.co.seulchuksaeng.seulchuksaengweb.dto.result.innerResult.EventReadInnerResult;
 import kr.co.seulchuksaeng.seulchuksaengweb.exception.event.NoEventException;
+import kr.co.seulchuksaeng.seulchuksaengweb.exception.event.NotValidAddressException;
+import kr.co.seulchuksaeng.seulchuksaengweb.exception.event.ParticipantGenderChangeException;
 import kr.co.seulchuksaeng.seulchuksaengweb.repository.MemberRepository;
 import kr.co.seulchuksaeng.seulchuksaengweb.service.EventService;
 import lombok.RequiredArgsConstructor;
@@ -72,7 +74,7 @@ public class EventController {
     public EventResult.Read readEvent(@RequestBody EventForm.Read eventReadForm, @AuthenticationPrincipal User user) {
         log.info("경기 조회 요청이 발생하였습니다 - 요청자 : {}, 경기 고유번호 : {}", user.getUsername(), eventReadForm.eventId());
         try {
-            EventReadInnerResult result = eventService.read(eventReadForm.eventId());
+            EventReadInnerResult result = eventService.read(eventReadForm.eventId(), user.getUsername());
             log.info("경기 조회에 성공하였습니다 - 요청자 : {}, 경기 고유번호 : {}", user.getUsername(), eventReadForm.eventId());
             return new EventResult.Read("success", "경기 조회에 성공하였습니다", result);
         } catch (NoEventException e) {
@@ -91,7 +93,7 @@ public class EventController {
             eventService.update(form);
             log.info("경기 내용 수정에 성공하였습니다 - 요청자 : {}, 경기 제목 : {}", user.getUsername(), form.title());
             return new EventResult.Update("success", "경기 내용 수정에 성공하였습니다");
-        } catch (NoEventException e) {
+        } catch (NoEventException | ParticipantGenderChangeException | NotValidAddressException e) {
             log.info("경기 내용 수정에 실패하였습니다 - 요청자 : {}, 경기 제목 : {}, 실패 사유 : {}", user.getUsername(), form.title(), e.getMessage());
             return new EventResult.Update("fail", e.getMessage());
         }

--- a/src/main/java/kr/co/seulchuksaeng/seulchuksaengweb/domain/MemberEvent.java
+++ b/src/main/java/kr/co/seulchuksaeng/seulchuksaengweb/domain/MemberEvent.java
@@ -66,8 +66,8 @@ public class MemberEvent {
             throw new EventAlreadyEndedException();
         }
 
-        // 20분 이상 늦으면 지각 처리
-        if (timeDifferenceStart.toMinutes() >= 20) {
+        // 늦으면 지각 처리
+        if (timeDifferenceStart.toMinutes() >= 0) {
             this.attend = Attendance.LATE;
             return Attendance.LATE;
         }

--- a/src/main/java/kr/co/seulchuksaeng/seulchuksaengweb/dto/result/innerResult/EventReadInnerResult.java
+++ b/src/main/java/kr/co/seulchuksaeng/seulchuksaengweb/dto/result/innerResult/EventReadInnerResult.java
@@ -1,6 +1,8 @@
 package kr.co.seulchuksaeng.seulchuksaengweb.dto.result.innerResult;
 
+import kr.co.seulchuksaeng.seulchuksaengweb.domain.Attendance;
 import kr.co.seulchuksaeng.seulchuksaengweb.domain.Gender;
+import kr.co.seulchuksaeng.seulchuksaengweb.domain.PurchaseStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,5 +17,7 @@ public record EventReadInnerResult(
         String description,
         LocalDateTime startTime,
         LocalDateTime endTime,
-        String location
+        String location,
+        Attendance attend,
+        PurchaseStatus purchaseStatus
 ) {}

--- a/src/main/java/kr/co/seulchuksaeng/seulchuksaengweb/exception/event/ParticipantGenderChangeException.java
+++ b/src/main/java/kr/co/seulchuksaeng/seulchuksaengweb/exception/event/ParticipantGenderChangeException.java
@@ -1,0 +1,5 @@
+package kr.co.seulchuksaeng.seulchuksaengweb.exception.event;
+
+public class ParticipantGenderChangeException extends RuntimeException {
+    public ParticipantGenderChangeException() { super("경기에 참여한 인원이 있어서 성별을 변경할 수 없습니다! "); }
+}

--- a/src/main/java/kr/co/seulchuksaeng/seulchuksaengweb/service/MemberEventService.java
+++ b/src/main/java/kr/co/seulchuksaeng/seulchuksaengweb/service/MemberEventService.java
@@ -81,7 +81,7 @@ public class MemberEventService {
         Member member = memberRepository.findMemberById(memberId);
         MemberEvent memberEvent = eventMemberRepository.findMemberEventByMemberAndEvent(member, event);
 
-        if (distanceCalc.calculateDistance(event.getLatitude(), event.getLongitude(), latitude, longitude) > 300) {
+        if (distanceCalc.calculateDistance(event.getLatitude(), event.getLongitude(), latitude, longitude) > 400) {
             throw new FarFromLocationException();
         }
 


### PR DESCRIPTION
#### 추가된 Feature
- 경기 조회시 출석, 납부 상황 리턴

#### 수정된 부분
- 참여인원 이미 있는 경기는 성별 수정 불가
- 출석 가능 거리 반경 400M로 연장
- 지각 시간을 경기 시작 후 20분에서 경기 시작 후 0분으로 변경